### PR TITLE
BUGFIX - fix drifting issue with enemy group row containing odd number of enemies

### DIFF
--- a/dist/scripts.js
+++ b/dist/scripts.js
@@ -232,7 +232,7 @@ EnemyConstants.levels = [
         level: 1,
         enemies: [
             [
-                EnemyType.WEAK,
+                // EnemyType.WEAK,
                 EnemyType.WEAK,
                 EnemyType.WEAK,
                 EnemyType.WEAK,
@@ -293,14 +293,15 @@ class EnemyGroup {
     calculateMaxRightPositionToMove(maxEnemiesInARow, rowLength, enemyIndex) {
         const spacesToRight = (maxEnemiesInARow - rowLength) / 2 + (rowLength - enemyIndex - 1);
         const maxRightPositionToMove = spacesToRight * Enemy.WIDTH +
-            Math.floor(spacesToRight) * this.ENEMY_SPACING +
+            spacesToRight * this.ENEMY_SPACING +
             this.ENEMY_SPACING;
-        return Math.floor(this.canvas.width - maxRightPositionToMove);
+        return this.canvas.width - maxRightPositionToMove;
     }
     calculateMinLeftPositionToMove(maxEnemiesInARow, rowLength, enemyIndex) {
         const spacesToLeft = (maxEnemiesInARow - rowLength) / 2 + enemyIndex;
-        return (Math.floor(spacesToLeft * Enemy.WIDTH +
-            Math.floor(spacesToLeft) * this.ENEMY_SPACING) + this.ENEMY_SPACING);
+        return (spacesToLeft * Enemy.WIDTH +
+            spacesToLeft * this.ENEMY_SPACING +
+            this.ENEMY_SPACING);
     }
     calculateRowOffset(rowLength) {
         const maxWidthOfRow = rowLength * Enemy.WIDTH + (rowLength - 1) * this.ENEMY_SPACING;

--- a/scripts/components/characters/enemies/EnemyGroup.ts
+++ b/scripts/components/characters/enemies/EnemyGroup.ts
@@ -66,9 +66,9 @@ class EnemyGroup {
       (maxEnemiesInARow - rowLength) / 2 + (rowLength - enemyIndex - 1);
     const maxRightPositionToMove =
       spacesToRight * Enemy.WIDTH +
-      Math.floor(spacesToRight) * this.ENEMY_SPACING +
+      spacesToRight * this.ENEMY_SPACING +
       this.ENEMY_SPACING;
-    return Math.floor(this.canvas.width - maxRightPositionToMove);
+    return this.canvas.width - maxRightPositionToMove;
   }
 
   private calculateMinLeftPositionToMove(
@@ -78,10 +78,9 @@ class EnemyGroup {
   ): number {
     const spacesToLeft = (maxEnemiesInARow - rowLength) / 2 + enemyIndex;
     return (
-      Math.floor(
-        spacesToLeft * Enemy.WIDTH +
-          Math.floor(spacesToLeft) * this.ENEMY_SPACING
-      ) + this.ENEMY_SPACING
+      spacesToLeft * Enemy.WIDTH +
+      spacesToLeft * this.ENEMY_SPACING +
+      this.ENEMY_SPACING
     );
   }
 


### PR DESCRIPTION
Fixing drifting issue with enemy group where one row has odd number of enemies.

The issue was that when a row in the enemy group contained an odd number of enemies, that row would move downward slightly after the other rows, causing a drifting effect. As the group continued moving downward, the drift compounded, becoming more and more noticeable.